### PR TITLE
Fix Sayal North facility mapping and refine barcode checkin aggregation

### DIFF
--- a/models/intermediate/normalized/facility_koboid_link_normalized.sql
+++ b/models/intermediate/normalized/facility_koboid_link_normalized.sql
@@ -24,4 +24,35 @@ deduplicated AS (
     ) }}
 )
 
-SELECT * FROM deduplicated
+SELECT
+    _airbyte_raw_id,
+    _id,
+    CASE
+        -- Correct the Kobo username typo so Sayal North submissions join downstream models.
+        WHEN facilityname = 'Sayal North Patratu'
+            AND kobo_username = 'savalnorthratratu'
+            THEN 'sayalnorthpatratu'
+        ELSE kobo_username
+    END AS kobo_username,
+    start,
+    starttime,
+    meta_deprecatedid,
+    endtime,
+    _validation_status,
+    "end",
+    formhub_uuid,
+    meta_instancename,
+    _uuid,
+    _xform_id_string,
+    _tags,
+    _submission_time,
+    meta_rootuuid,
+    _geolocation,
+    facilityname,
+    _status,
+    meta_instanceid,
+    _attachments,
+    _submitted_by,
+    _notes,
+    __version__
+FROM deduplicated

--- a/models/prod/final/data_barcode_checkin_agg.sql
+++ b/models/prod/final/data_barcode_checkin_agg.sql
@@ -102,7 +102,7 @@ expected_checkins_by_facility_position AS (
   UNION ALL SELECT 'Bairo', 'Cleaning', 2
   UNION ALL SELECT 'Bairo', 'Night Guard', 1
   
-  UNION ALL SELECT 'Bela Museri', 'Data Collector', 3
+  UNION ALL SELECT 'Bela Museri', 'Data Collector', 2
   UNION ALL SELECT 'Bela Museri', 'Cleaning', 2
   UNION ALL SELECT 'Bela Museri', 'Night Guard', 1
   
@@ -135,7 +135,8 @@ daily_checkins_by_position AS (
     facility,
     date_auto,
     standardized_position,
-    COUNT(*) AS actual_checkins
+    COUNT(DISTINCT userid) AS actual_checkins,
+    COUNT(*) AS actual_checkin_events
   FROM checkins_with_standard_positions
   WHERE date_auto IS NOT NULL
   GROUP BY facility, date_auto, standardized_position


### PR DESCRIPTION
## Summary
- correct the Kobo username mapping for `Sayal North Patratu` so downstream joins pick up live submissions
- refine `data_barcode_checkin_agg` to count distinct users for `actual_checkins`
- adjust the expected `Data Collector` checkins for `Bela Museri` from 3 to 2

## Validation
- ran `dbt build --target dev -s +data_barcode_checkin +usetracking_dashboard +daily_issue_dashboard --exclude data_barcode_checkin_agg missing_checkins_data`
- ran `dbt build --target dev -s data_barcode_checkin_agg missing_checkins_data`
- verified `prod_final.data_barcode_checkin` and `prod_final.usetracking_dashboard` contain `Sayal North Patratu` rows after the production refresh
